### PR TITLE
fix(deploy): set Vite output directory and build command in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "outputDirectory": "dist",
+  "buildCommand": "npm run build",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
Vercel was looking for the old CRA output directory "build" but Vite outputs to "dist". Setting outputDirectory to "dist" and explicitly declaring the build command resolves the deploy failure.